### PR TITLE
Auto-refresh charts every 5s

### DIFF
--- a/src/containers/MainChart/index.js
+++ b/src/containers/MainChart/index.js
@@ -143,13 +143,9 @@ class MainChartScreen extends React.Component {
   }
 
   updateChart = async () => {
-    try {
-      await this.internalUpdateChart();
-    } finally {
-      // Trigger next call
-      if (!this.reachEndTime) {
-        this.callTimerID = setTimeout(this.updateChart, interval);
-      }
+    await this.internalUpdateChart();
+    if (this.reachEndTime) {
+      clearInterval(this.callTimerID);
     }
   };
 
@@ -293,7 +289,7 @@ class MainChartScreen extends React.Component {
     chartManager.registerRenderCharts(true);
 
     if (moment(dateStr).format("yyyy/MM/DD") === this.realTimeDate) {
-      this.callTimerID = setTimeout(this.updateChart, interval);
+      this.callTimerID = setInterval(this.updateChart, interval);
     }
 
     this.setState({ isLoading: false });


### PR DESCRIPTION
## Summary
- use setInterval to refresh charts every 5s
- stop interval once simulation reaches end

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689024362cdc832c81965153304f4794