### PR TITLE
Increase auto refresh interval to 20s

### DIFF
--- a/src/containers/Demo/index.js
+++ b/src/containers/Demo/index.js
@@ -28,7 +28,7 @@ CanvasJS.addColorSet("customColorSet1",
   "#EB8CC6",
 ]);
 
-const interval = 5000;
+const interval = 20000;
 
 const styles = {
   container: {

--- a/src/containers/MainBubbleChart/index.js
+++ b/src/containers/MainBubbleChart/index.js
@@ -28,7 +28,7 @@ CanvasJS.addColorSet("customColorSet1", [
   "#EB8CC6",
 ]);
 
-const interval = 5000;
+const interval = 20000;
 
 const styles = {
   container: {

--- a/src/containers/MainChart/index.js
+++ b/src/containers/MainChart/index.js
@@ -40,7 +40,7 @@ CanvasJS.addColorSet("customColorSet1", [
   "#EB8CC6",
 ]);
 
-const interval = 5000;
+const interval = 20000;
 
 const styles = {
   container: {


### PR DESCRIPTION
## Summary
- extend chart auto-refresh intervals to 20 seconds for main and bubble demo screens

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6892fe0cbcbc832caddb969cd07d50ce