### PR TITLE
Enable lazy loading for main charts

### DIFF
--- a/src/containers/MainChart/index.css
+++ b/src/containers/MainChart/index.css
@@ -53,4 +53,21 @@
     justify-content: center;
     z-index: 9999;
   }
+
+.chart-wrapper {
+    position: relative;
+}
+
+.chart-loading {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1;
+}
   


### PR DESCRIPTION
## Summary
- Load main charts in parallel without blocking UI
- Initialize CanvasJS view range and rendering after all data fetches complete
- Show per-chart loading spinners while each chart's data loads

## Testing
- `CI=true npm test --silent` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6899547d18b0832c91415fb83baadb6f